### PR TITLE
fix: add extension to filename

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -23,7 +23,7 @@ export class App extends React.Component {
       scannerSelected: null,
       inProgress: false,
       isScanned: false,
-      fileName: "image"
+      fileName: "image.png"
     }
   }
 


### PR DESCRIPTION
Add the extension png to the file name of the scan